### PR TITLE
Dev/clean terraform

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -1,25 +1,25 @@
 resource "google_project_service" "billing" {
-  service = "billingbudgets.googleapis.com"
-  project = var.runtime_project
+  service            = "billingbudgets.googleapis.com"
+  project            = var.runtime_project
   disable_on_destroy = true
 }
 resource "google_project_service" "iam" {
-  service = "iam.googleapis.com"
-  project = var.runtime_project
+  service            = "iam.googleapis.com"
+  project            = var.runtime_project
   disable_on_destroy = true
 }
 resource "google_project_service" "cloudrun" {
-  service = "run.googleapis.com"
-  project = var.runtime_project
+  service            = "run.googleapis.com"
+  project            = var.runtime_project
   disable_on_destroy = true
 }
 resource "google_project_service" "monitoring" {
-  service = "monitoring.googleapis.com"
-  project = var.runtime_project
+  service            = "monitoring.googleapis.com"
+  project            = var.runtime_project
   disable_on_destroy = true
 }
 resource "google_project_service" "pubsub" {
-  service = "pubsub.googleapis.com"
-  project = var.runtime_project
+  service            = "pubsub.googleapis.com"
+  project            = var.runtime_project
   disable_on_destroy = true
 }

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -1,6 +1,6 @@
 resource "google_cloud_run_service" "multi_org" {
-  name = var.cloud_run_service_name
-  project = var.runtime_project
+  name     = var.cloud_run_service_name
+  project  = var.runtime_project
   location = var.region
 
   template {
@@ -8,11 +8,11 @@ resource "google_cloud_run_service" "multi_org" {
       containers {
         image = var.image_tag
         env {
-          name = "BILLING_ACCOUNT"
+          name  = "BILLING_ACCOUNT"
           value = var.billing_account
         }
         env {
-          name = "BILLING_PROJECT"
+          name  = "BILLING_PROJECT"
           value = var.billing_project
         }
       }
@@ -21,7 +21,7 @@ resource "google_cloud_run_service" "multi_org" {
   }
 
   traffic {
-    percent = 100
+    percent         = 100
     latest_revision = true
   }
   depends_on = [google_project_service.cloudrun]
@@ -29,8 +29,8 @@ resource "google_cloud_run_service" "multi_org" {
 
 resource "google_cloud_run_service_iam_binding" "binding" {
   location = google_cloud_run_service.multi_org.location
-  project = google_cloud_run_service.multi_org.project
-  service = google_cloud_run_service.multi_org.name
-  role = "roles/run.invoker"
+  project  = google_cloud_run_service.multi_org.project
+  service  = google_cloud_run_service.multi_org.name
+  role     = "roles/run.invoker"
   members  = concat(var.members, ["serviceAccount:${google_service_account.pubsub.email}"])
 }

--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -20,6 +20,10 @@ resource "google_cloud_run_service" "multi_org" {
     }
   }
 
+  metadata {
+    labels = var.cloud_run_labels
+  }
+
   traffic {
     percent         = 100
     latest_revision = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,9 +1,9 @@
 provider "google" {
   project = var.runtime_project
-  region = var.region
+  region  = var.region
 }
 
 provider "google-beta" {
   project = var.runtime_project
-  region = var.region
+  region  = var.region
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,9 +1,0 @@
-provider "google" {
-  project = var.runtime_project
-  region  = var.region
-}
-
-provider "google-beta" {
-  project = var.runtime_project
-  region  = var.region
-}

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -1,28 +1,25 @@
 resource "google_pubsub_topic" "multi_org_billing" {
-  name = var.pubsub_topic_name
+  name    = var.pubsub_topic_name
   project = var.runtime_project
 }
 
-
-
 resource "google_pubsub_subscription" "multi_org_billing" {
-  name  = var.pubsub_subscription_name
+  name    = var.pubsub_subscription_name
   project = var.runtime_project
-  topic = google_pubsub_topic.multi_org_billing.name
+  topic   = google_pubsub_topic.multi_org_billing.name
 
   push_config {
     push_endpoint = "${google_cloud_run_service.multi_org.status[0].url}/pubsub"
     oidc_token {
       service_account_email = google_service_account.pubsub.email
-      audience = google_cloud_run_service.multi_org.status[0].url
+      audience              = google_cloud_run_service.multi_org.status[0].url
     }
   }
 }
 
 resource "google_pubsub_topic_iam_binding" "binding" {
   project = google_pubsub_topic.multi_org_billing.project
-  topic = google_pubsub_topic.multi_org_billing.name
-  role = "roles/pubsub.publisher"
-  members  = var.members
+  topic   = google_pubsub_topic.multi_org_billing.name
+  role    = "roles/pubsub.publisher"
+  members = var.members
 }
-

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -1,6 +1,7 @@
 resource "google_pubsub_topic" "multi_org_billing" {
   name    = var.pubsub_topic_name
   project = var.runtime_project
+  labels  = var.pubsub_topic_labels
 }
 
 resource "google_pubsub_subscription" "multi_org_billing" {

--- a/terraform/serviceaccount.tf
+++ b/terraform/serviceaccount.tf
@@ -1,24 +1,24 @@
 resource "google_service_account" "cloud_run" {
-  account_id   = var.service_account_name
-  project = var.runtime_project
+  account_id = var.service_account_name
+  project    = var.runtime_project
 }
 
 resource "google_project_iam_binding" "project" {
-  project     = var.billing_project
-  role = "roles/monitoring.notificationChannelEditor"
+  project = var.billing_project
+  role    = "roles/monitoring.notificationChannelEditor"
   members = [
     "serviceAccount:${google_service_account.cloud_run.email}",
   ]
 }
 
 resource "google_billing_account_iam_member" "billing_account_admin" {
-  provider = google-beta
+  provider           = google-beta
   billing_account_id = var.billing_account
-  role = "roles/billing.admin"
-  member = "serviceAccount:${google_service_account.cloud_run.email}"
+  role               = "roles/billing.admin"
+  member             = "serviceAccount:${google_service_account.cloud_run.email}"
 }
 
 resource "google_service_account" "pubsub" {
-  account_id   = "pubsub-call-cloud-run"
-  project = var.runtime_project
+  account_id = "pubsub-call-cloud-run"
+  project    = var.runtime_project
 }

--- a/terraform/serviceaccount.tf
+++ b/terraform/serviceaccount.tf
@@ -12,7 +12,6 @@ resource "google_project_iam_binding" "project" {
 }
 
 resource "google_billing_account_iam_member" "billing_account_admin" {
-  provider           = google-beta
   billing_account_id = var.billing_account
   role               = "roles/billing.admin"
   member             = "serviceAccount:${google_service_account.cloud_run.email}"

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,17 +1,17 @@
 // REQUIRED variables
 
 // The project that will host the resources (service account, pubsub, cloud run)
-runtime_project=""
+runtime_project = ""
 // The project that will host the notification channel email (for sending emails)
-billing_project=""
+billing_project = ""
 // The billing account on which to create the budget alerts
-billing_account=""
+billing_account = ""
 // The list of authorized account (user, service or group) to access to Cloud Run and PubSub topic to publish message.
 // The fully qualified account format is required. For example
 //  * user:user@email.com
 //  * group:group@email.com
 //  * serviceAccount:sa@email.com
-members=[]
+members = []
 
 
 // OPTIONAL variables

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,3 +48,15 @@ variable "pubsub_subscription_name" {
   type    = string
   default = "multi-org-billing-alert-subscription"
 }
+
+variable "cloud_run_labels" {
+  description = "Map of string keys and values that can be used to organize and categorize (scope and select) objects."
+  type        = map(string)
+  default     = {}
+}
+
+variable "pubsub_topic_labels" {
+  description = "Map of string keys and values that can be used to organize and categorize (scope and select) objects."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,13 +1,16 @@
 variable "billing_project" {
   description = "The project that will host the resources (service account, pubsub, cloud run)"
+  type        = string
 }
 
 variable "runtime_project" {
   description = "The project that will host the notification channel email (for sending emails)"
+  type        = string
 }
 
 variable "billing_account" {
   description = "The billing account on which to create the budget alerts"
+  type        = string
 }
 
 variable "members" {
@@ -17,25 +20,31 @@ variable "members" {
 }
 
 variable "image_tag" {
+  type    = string
   default = "us-central1-docker.pkg.dev/gblaquiere-dev/public/multi-org-billing-alert:1.4"
 }
 
 variable "region" {
+  type    = string
   default = "us-central1"
 }
 
 variable "service_account_name" {
+  type    = string
   default = "multi(org-billing"
 }
 
 variable "cloud_run_service_name" {
+  type    = string
   default = "multi-org-billing-alert"
 }
 
 variable "pubsub_topic_name" {
+  type    = string
   default = "multi-org-billing-alert-topic"
 }
 
 variable "pubsub_subscription_name" {
+  type    = string
   default = "multi-org-billing-alert-subscription"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,34 +1,41 @@
 variable "billing_project" {
   description = "The project that will host the resources (service account, pubsub, cloud run)"
 }
+
 variable "runtime_project" {
   description = "The project that will host the notification channel email (for sending emails)"
 }
+
 variable "billing_account" {
   description = "The billing account on which to create the budget alerts"
 }
+
 variable "members" {
   description = "The list of authorized account (user, service or group) to access to Cloud Run and PubSub topic to publish message. The fully qualified account format is required. For example user:user@email.com or group:group@email.com or serviceAccount:sa@email.com"
-  type=list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
-
 
 variable "image_tag" {
   default = "us-central1-docker.pkg.dev/gblaquiere-dev/public/multi-org-billing-alert:1.4"
 }
+
 variable "region" {
   default = "us-central1"
 }
+
 variable "service_account_name" {
   default = "multi(org-billing"
 }
+
 variable "cloud_run_service_name" {
   default = "multi-org-billing-alert"
 }
+
 variable "pubsub_topic_name" {
   default = "multi-org-billing-alert-topic"
 }
+
 variable "pubsub_subscription_name" {
   default = "multi-org-billing-alert-subscription"
 }


### PR DESCRIPTION
Add support for tags on the Cloud Run instance and Pub/Sub topic.

Also removed the Provider configuration to let the calling project handle those (for example with service account impersonation)